### PR TITLE
GH-Action: GLMakie needs add xvfb-run

### DIFF
--- a/.github/workflows/Export.yml
+++ b/.github/workflows/Export.yml
@@ -45,8 +45,9 @@ jobs:
 
 
             - name: Run & export Pluto notebooks
+            
               run: |
-                julia -e '
+                 DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia -e '
                   import Pkg
                   Pkg.activate("pluto-deployment-environment")
                   Pkg.instantiate()


### PR DESCRIPTION
this might allow the `heatmap` featured notebook to work #10. I say might, because maybe one needs to install some packages first..
```
      - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
 ```
see https://github.com/MakieOrg/Makie.jl/actions/runs/5918149329/workflow#L47