### PR TITLE
Update/attribution

### DIFF
--- a/src/language/Structure and language.jl
+++ b/src/language/Structure and language.jl
@@ -6,6 +6,8 @@
 #> title = "Structure and language"
 #> tags = ["language", "natural language processing", "language modelling", "natural language generation", "homework"]
 #> description = "Automatically detect the language of a piece of text, and generate realistic-looking random text!"
+#> license = "MIT / CC BY-SA 4.0"
+#> license_url = "https://github.com/mitmath/computational-thinking/blob/Fall23/LICENSE.md"
 #> 
 #>     [[frontmatter.author]]
 #>     name = "MIT Computational Thinking"

--- a/src/machine-learning/substitution-ciphers-1.jl
+++ b/src/machine-learning/substitution-ciphers-1.jl
@@ -11,8 +11,8 @@
 #> description = "Learn about optimisation by solving ceasar ciphers!"
 #> 
 #>     [[frontmatter.author]]
-#>     name = "Pluto.jl"
-#>     url = "https://github.com/JuliaPluto"
+#>     name = "Luka van der Plas"
+#>     url = "https://github.com/lukavdplas"
 
 using Markdown
 using InteractiveUtils

--- a/src/machine-learning/substitution-ciphers-2.jl
+++ b/src/machine-learning/substitution-ciphers-2.jl
@@ -11,8 +11,8 @@
 #> description = "Learn about optimisation by solving substitution ciphers!"
 #> 
 #>     [[frontmatter.author]]
-#>     name = "Pluto.jl"
-#>     url = "https://github.com/JuliaPluto"
+#>     name = "Luka van der Plas"
+#>     url = "https://github.com/lukavdplas"
 
 using Markdown
 using InteractiveUtils

--- a/src/pluto_export_configuration.json
+++ b/src/pluto_export_configuration.json
@@ -30,6 +30,11 @@
             "tags": ["language"]
         },
         {
+            "title": "Puzzles & Games",
+            "description": "Have fun with some recreational programming!",
+            "tags": ["puzzle", "game"]
+        },
+        {
             "title": "Pluto and the Web",
             "description": "Pluto is a fantastic tool for connecting Julia to the web! Learn more about using HTML, CSS and JavaScript in Pluto to take your visualization skills to the next level.",
             "tags": ["web"]

--- a/src/puzzles-games/Tower of Hanoi.jl
+++ b/src/puzzles-games/Tower of Hanoi.jl
@@ -1,16 +1,16 @@
 ### A Pluto.jl notebook ###
-# v0.19.27
+# v0.19.36
 
 #> [frontmatter]
+#> license_url = "https://github.com/JuliaPluto/featured/blob/2a6a9664e5428b37abe4957c1dca0994f4a8b7fd/LICENSES/Unlicense"
 #> image = "https://upload.wikimedia.org/wikipedia/commons/0/07/Tower_of_Hanoi.jpeg"
 #> tags = ["classic", "puzzle"]
 #> license = "Unlicense"
-#> license_url = "https://github.com/JuliaPluto/featured/blob/2a6a9664e5428b37abe4957c1dca0994f4a8b7fd/LICENSES/Unlicense"
 #> description = "An interactive Julia puzzle about stacking disks."
 #> 
 #>     [[frontmatter.author]]
-#>     name = "Pluto.jl"
-#>     url = "https://github.com/JuliaPluto"
+#>     name = "Luka van der Plas"
+#>     url = "https://github.com/lukavdplas"
 
 using Markdown
 using InteractiveUtils

--- a/src/puzzles-games/Tower of Hanoi.jl
+++ b/src/puzzles-games/Tower of Hanoi.jl
@@ -3,7 +3,7 @@
 
 #> [frontmatter]
 #> image = "https://upload.wikimedia.org/wikipedia/commons/0/07/Tower_of_Hanoi.jpeg"
-#> tags = ["basic", "classic"]
+#> tags = ["classic", "puzzle"]
 #> license = "Unlicense"
 #> license_url = "https://github.com/JuliaPluto/featured/blob/2a6a9664e5428b37abe4957c1dca0994f4a8b7fd/LICENSES/Unlicense"
 #> description = "An interactive Julia puzzle about stacking disks."
@@ -21,7 +21,7 @@ md"""
 
 The tower of hanoi is a famous puzzle.
 
-![setup of the tower of a hanoi](https://upload.wikimedia.org/wikipedia/commons/0/07/Tower_of_Hanoi.jpeg)
+![setup of the tower of hanoi](https://upload.wikimedia.org/wikipedia/commons/0/07/Tower_of_Hanoi.jpeg)
 
 The game consists of three rods with disks stacked on top of them. The puzzle will start with all disks in a stack on one of the rods (like in the picture). The goal is to move all the discs to a single stack on the last rod.
 


### PR DESCRIPTION
Minor changes to attribution and the page organisation:

- Adds a license URL to the MIT notebook :)
- Moves the Tower of Hanoi notebook from "basic" to a "puzzles & games" category
- Changes the author of three notebooks (tower of hanoi and the cipher notebooks) from Pluto.jl to myself. 
- Fixes one typo in the Tower of Hanoi notebook.

This last point isn't really because I want to credited personally, but because I think the "Pluto.jl" author creates an impression of authority, like those are the "official" notebooks. That is accurate for notebooks like the introduction to markdown, which is a fundamental tutorial.

The notebooks in question are more related to my personal interests rather than Pluto fundamentals, and I'd consider them to have the same status as notebooks by other contributors.