### PR TITLE
Added magic notebook

### DIFF
--- a/src/basic/magic-notebook.jl
+++ b/src/basic/magic-notebook.jl
@@ -1353,7 +1353,6 @@ version = "17.7.0+0"
 """
 
 # ╔═╡ Cell order:
-# ╠═be844db0-bf12-11f0-3f35-a981c30c2bf5
 # ╟─d4a44096-79af-479f-994c-8de983feb76c
 # ╟─6daac7c1-efd8-4200-aa3a-d564bcf687c3
 # ╟─26bd9a9d-b1f6-44a5-a716-34518b4c5ae4
@@ -1384,6 +1383,7 @@ version = "17.7.0+0"
 # ╟─4c1ea556-72fb-4f5a-a1a0-b2af8e9fd22d
 # ╟─665ddd8e-dc5b-4925-a283-aebe7d16592c
 # ╟─cea778b1-8cf9-4abb-8114-35fe36906351
+# ╠═be844db0-bf12-11f0-3f35-a981c30c2bf5
 # ╟─8d330a5c-9db4-4016-90ab-2c82d4be09cb
 # ╟─82f80e24-5997-46d9-9c8b-e7e60780f4b0
 # ╟─5972906a-ab4c-42b7-8d6f-554361293f4d


### PR DESCRIPTION
This notebook shows how to use the new Switch UI element to customize a Pluto notebook 🎉 

We use the Math Art notebook as a start and add some custom features. 
- You can toggle beginner mode to add a new section explaining basic concepts or toggle it off and skip to the main part about math art. 
- You can toggle math mode to show or hide the formulas depending on whether you understand better with math or not
- You can toggle color-blind friendly color for the final color 

This notebook should help show how markdown is also part of the code that can be played with + this should offer a template to reuse to customize notebooks for classes, if say they're meant for a wide audience (by switching and on and off full section, the notebook magically adapts its full content depending on who is reading it :)) 

Some tiny fixes are still needed:
1. Using `aside` function from `PlutoTeachingTools` the `$variable` doesn't work, it only shows the name of the variable not its content
2. We should probably fix the PlutoImagePicker (also for the Math Art notebook) because on some hovers it selects the objects and the colors then kinda look weird 